### PR TITLE
Add a paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ This kind of hallucination denotes the model response deviates from the *user in
 + `Data-to-text`:
   + **Controlling Hallucinations at Word Level in Data-to-Text Generation**
   *Clément Rebuffel, Marco Roberti, Laure Soulier, Geoffrey Scoutheeten, Rossella Cancelliere, Patrick Gallinari*[[paper]](https://arxiv.org/abs/2102.02810) 2021.2
-  + **On Hallucination and Predictive Uncertainty in Conditional Language Generation***Yijun Xiao, William Yang Wang*[[paper]](https://arxiv.org/abs/2103.15025) 2021.3
-  + **Faithful Low-Resource Data-to-Text Generation through Cycle Training***Zhuoer Wang, Marcus Collins, Nikhita Vedula, Simone Filice, Shervin Malmasi, Oleg Rokhlenko*[[paper]](https://aclanthology.org/2023.acl-long.160/) 2023.7
+  + **On Hallucination and Predictive Uncertainty in Conditional Language Generation**
+  *Yijun Xiao, William Yang Wang*[[paper]](https://arxiv.org/abs/2103.15025) 2021.3
+  + **Faithful Low-Resource Data-to-Text Generation through Cycle Training**
+  *Zhuoer Wang, Marcus Collins, Nikhita Vedula, Simone Filice, Shervin Malmasi, Oleg Rokhlenko*[[paper]](https://aclanthology.org/2023.acl-long.160/) 2023.7
 + `Summarization`:
   + **On Faithfulness and Factuality in Abstractive Summarization**
   *Joshua Maynez, Shashi Narayan, Bernd Bohnet, Ryan McDonald*[[paper]](https://arxiv.org/abs/2005.00661) 2020.5

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This kind of hallucination denotes the model response deviates from the *user in
   + **Controlling Hallucinations at Word Level in Data-to-Text Generation**
   *Clément Rebuffel, Marco Roberti, Laure Soulier, Geoffrey Scoutheeten, Rossella Cancelliere, Patrick Gallinari*[[paper]](https://arxiv.org/abs/2102.02810) 2021.2
   + **On Hallucination and Predictive Uncertainty in Conditional Language Generation***Yijun Xiao, William Yang Wang*[[paper]](https://arxiv.org/abs/2103.15025) 2021.3
+  + **Faithful Low-Resource Data-to-Text Generation through Cycle Training***Zhuoer Wang, Marcus Collins, Nikhita Vedula, Simone Filice, Shervin Malmasi, Oleg Rokhlenko*[[paper]](https://aclanthology.org/2023.acl-long.160/) 2023.7
 + `Summarization`:
   + **On Faithfulness and Factuality in Abstractive Summarization**
   *Joshua Maynez, Shashi Narayan, Bernd Bohnet, Ryan McDonald*[[paper]](https://arxiv.org/abs/2005.00661) 2020.5

--- a/README.md
+++ b/README.md
@@ -363,6 +363,10 @@ An interesting new work proposed tuning LLMs on some synthetic tasks, which they
 1. **Teaching Language Models to Hallucinate Less with Synthetic Tasks**
    *Erik Jones, Hamid Palangi, Clarisse Simões, Varun Chandrasekaran, Subhabrata Mukherjee, Arindam Mitra, Ahmed Awadallah, Ece Kamar* [[paper]](https://arxiv.org/abs/2310.06827) 2023.10
 
+Recent work suggests that hallucinations can also be mitigated by leveraging unlabeled/unpaired data with cycle training:
+1. **Faithful Low-Resource Data-to-Text Generation through Cycle Training**
+  *Zhuoer Wang, Marcus Collins, Nikhita Vedula, Simone Filice, Shervin Malmasi, Oleg Rokhlenko*[[paper]](https://aclanthology.org/2023.acl-long.160/) 2023.7
+
 ### Mitigation During RLHF
 
 1. **Training language models to follow instructions with human feedback**


### PR DESCRIPTION
Add an ACL 2023 outstanding paper that targets input-conflicting hallucination for the data-to-text generation task. 
The work proposed 
- a new human evaluation schema to quantify input-conflicting hallucination (corresponding to the section _🔍Evaluation of LLM Hallucination - Input-conflicting Hallucination - Data-to-text_) 
- a mitigation strategy that reduces hallucinations by leveraging unlabeled/unpaired data with cycle training (corresponding to the section _🛠Mitigation of LLM Hallucination - Mitigation During SFT_, added a special note as the approach uses unlabeled/unpaired data)